### PR TITLE
feat: Implement playlist detail screen with song management features

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -2,6 +2,7 @@ import { HorizontalAlbumList } from "@/components/home/HorizontalAlbumList";
 import { HorizontalSongList } from "@/components/home/HorizontalSongList";
 import { SaavnAlbum } from "@/services/SongApiService";
 import { useHomeStore } from "@/store/homeStore";
+import { router } from "expo-router";
 import React, { useEffect } from "react";
 import { RefreshControl, ScrollView, Text, View } from "react-native";
 
@@ -47,8 +48,7 @@ export default function HomeScreen() {
   };
 
   const handleAlbumPress = (album: SaavnAlbum) => {
-    // TODO: Navigate to album details
-    console.log("Album pressed:", album.name);
+    router.push(`/album/${album.id}`);
   };
 
   return (

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -68,6 +68,27 @@ export default function RootLayout() {
             name="playlists"
             options={{ title: "Playlists", headerShown: false }}
           />
+          <Stack.Screen
+            name={"album/[id]"}
+            options={{
+              title: "Album",
+              headerShown: false,
+            }}
+          />
+          <Stack.Screen
+            name={"playlist/[id]"}
+            options={{
+              title: "Playlist",
+              headerShown: false,
+            }}
+          />
+          <Stack.Screen
+            name={"playlist/local/[id]"}
+            options={{
+              title: "Playlist",
+              headerShown: true,
+            }}
+          />
         </Stack>
         <StatusBar style="auto" />
         <MiniPlayer />

--- a/app/album/[id].tsx
+++ b/app/album/[id].tsx
@@ -1,0 +1,314 @@
+import {
+  SaavnAlbum,
+  SaavnSong,
+  getAlbumDetails,
+} from "@/services/SongApiService";
+import { usePlayerStore } from "@/store/playerStore";
+import { Image } from "expo-image";
+import { router, useLocalSearchParams } from "expo-router";
+import React, { useEffect, useState } from "react";
+import {
+  ActivityIndicator,
+  Alert,
+  FlatList,
+  Text,
+  TouchableOpacity,
+  View,
+} from "react-native";
+
+interface AlbumDetails extends SaavnAlbum {
+  songs: SaavnSong[];
+  description?: string;
+  releaseDate?: string;
+  genre?: string;
+}
+
+export default function AlbumDetailScreen() {
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const [album, setAlbum] = useState<AlbumDetails | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const {
+    playNow,
+    addToQueue,
+    shufflePlay,
+    playInOrder,
+    queue,
+    currentTrack,
+    isPlaying,
+  } = usePlayerStore();
+
+  useEffect(() => {
+    if (id) {
+      fetchAlbumDetails(id);
+    }
+  }, [id]);
+
+  const fetchAlbumDetails = async (albumId: string) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await getAlbumDetails(albumId);
+
+      if (result) {
+        const albumDetails: AlbumDetails = {
+          ...result.album,
+          songs: result.songs,
+        };
+        setAlbum(albumDetails);
+      } else {
+        setError("Album not found");
+      }
+    } catch (err) {
+      setError("Failed to load album details");
+      console.error("Album fetch error:", err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handlePlayAll = () => {
+    if (album?.songs && album.songs.length > 0) {
+      playInOrder(album.songs);
+    }
+  };
+
+  const handleShuffle = () => {
+    if (album?.songs && album.songs.length > 0) {
+      const shuffledSongs = [...album.songs].sort(() => Math.random() - 0.5);
+      shufflePlay(shuffledSongs);
+    }
+  };
+
+  const handleSongPress = (song: SaavnSong, index: number) => {
+    if (album?.songs) {
+      // Play from this song onwards
+      const songsFromIndex = album.songs.slice(index);
+      playInOrder(songsFromIndex);
+    }
+  };
+
+  const handleAddToQueue = (song: SaavnSong) => {
+    addToQueue(song);
+    Alert.alert(
+      "Added to Queue",
+      `"${song.name}" has been added to your queue.`
+    );
+  };
+
+  const formatDuration = (seconds?: number) => {
+    if (!seconds) return "--:--";
+    const mins = Math.floor(seconds / 60);
+    const secs = seconds % 60;
+    return `${mins}:${secs.toString().padStart(2, "0")}`;
+  };
+
+  const renderSongItem = ({
+    item,
+    index,
+  }: {
+    item: SaavnSong;
+    index: number;
+  }) => {
+    const isCurrentSong = currentTrack?.id === item.id;
+
+    return (
+      <TouchableOpacity
+        onPress={() => handleSongPress(item, index)}
+        onLongPress={() => handleAddToQueue(item)}
+        className={`flex-row items-center p-4 ${
+          isCurrentSong ? "bg-blue-500/20" : "active:bg-neutral-800"
+        }`}
+      >
+        {/* Track Number */}
+        <View className="w-8 items-center mr-3">
+          {isCurrentSong && isPlaying ? (
+            <View className="flex-row space-x-1">
+              <View className="w-1 h-4 bg-blue-500 rounded-full animate-pulse" />
+              <View
+                className="w-1 h-4 bg-blue-500 rounded-full animate-pulse"
+                style={{ animationDelay: "0.2s" }}
+              />
+              <View
+                className="w-1 h-4 bg-blue-500 rounded-full animate-pulse"
+                style={{ animationDelay: "0.4s" }}
+              />
+            </View>
+          ) : (
+            <Text
+              className={`text-sm ${isCurrentSong ? "text-blue-500" : "text-neutral-400"}`}
+            >
+              {(index + 1).toString().padStart(2, "0")}
+            </Text>
+          )}
+        </View>
+
+        {/* Song Info */}
+        <View className="flex-1">
+          <Text
+            className={`text-base font-medium ${
+              isCurrentSong ? "text-blue-500" : "text-neutral-100"
+            }`}
+            numberOfLines={1}
+          >
+            {item.name}
+          </Text>
+          {item.primaryArtists && (
+            <Text className="text-neutral-400 text-sm mt-1" numberOfLines={1}>
+              {item.primaryArtists}
+            </Text>
+          )}
+        </View>
+
+        {/* Duration */}
+        <Text className="text-neutral-400 text-sm ml-2">
+          {formatDuration(item.duration)}
+        </Text>
+
+        {/* More Options */}
+        <TouchableOpacity
+          onPress={() => handleAddToQueue(item)}
+          className="p-2 ml-2"
+        >
+          <Text className="text-neutral-400 text-lg">⋯</Text>
+        </TouchableOpacity>
+      </TouchableOpacity>
+    );
+  };
+
+  if (loading) {
+    return (
+      <View className="flex-1 bg-neutral-950 justify-center items-center">
+        <ActivityIndicator size="large" color="#3b82f6" />
+        <Text className="text-neutral-400 mt-4">Loading album...</Text>
+      </View>
+    );
+  }
+
+  if (error) {
+    return (
+      <View className="flex-1 bg-neutral-950 justify-center items-center px-6">
+        <Text className="text-red-400 text-lg text-center mb-4">{error}</Text>
+        <TouchableOpacity
+          onPress={() => id && fetchAlbumDetails(id)}
+          className="bg-blue-500 px-6 py-3 rounded-xl"
+        >
+          <Text className="text-white font-semibold">Retry</Text>
+        </TouchableOpacity>
+      </View>
+    );
+  }
+
+  if (!album) {
+    return (
+      <View className="flex-1 bg-neutral-950 justify-center items-center">
+        <Text className="text-neutral-400">Album not found</Text>
+      </View>
+    );
+  }
+
+  return (
+    <View className="flex-1 bg-neutral-950">
+      <FlatList
+        data={album.songs}
+        keyExtractor={(item, index) => `${item.id}-${index}`}
+        renderItem={renderSongItem}
+        contentContainerStyle={{ paddingBottom: 100 }}
+        ListHeaderComponent={
+          <View>
+            {/* Header with back button */}
+            <View className="flex-row items-center justify-between pt-16 pb-4 px-6">
+              <TouchableOpacity onPress={() => router.back()}>
+                <Text className="text-neutral-300 text-2xl">‹</Text>
+              </TouchableOpacity>
+              <TouchableOpacity>
+                <Text className="text-neutral-300 text-2xl">⋯</Text>
+              </TouchableOpacity>
+            </View>
+
+            {/* Album Cover and Info */}
+            <View className="items-center px-6 pb-8">
+              {album.image ? (
+                <Image
+                  source={{ uri: album.image }}
+                  style={{ width: 280, height: 280, borderRadius: 16 }}
+                  transition={300}
+                />
+              ) : (
+                <View className="w-70 h-70 rounded-2xl bg-neutral-800 justify-center items-center">
+                  <Text className="text-neutral-400 text-4xl">🎵</Text>
+                </View>
+              )}
+
+              <Text className="text-neutral-100 text-2xl font-bold mt-6 text-center">
+                {album.name}
+              </Text>
+
+              {album.primaryArtists && (
+                <Text className="text-neutral-300 text-lg mt-2 text-center">
+                  {album.primaryArtists}
+                </Text>
+              )}
+
+              <View className="flex-row items-center space-x-4 mt-3">
+                {album.year && (
+                  <Text className="text-neutral-400 text-sm">{album.year}</Text>
+                )}
+                {album.songCount && (
+                  <Text className="text-neutral-400 text-sm">
+                    {album.songCount} songs
+                  </Text>
+                )}
+              </View>
+
+              {album.description && (
+                <Text className="text-neutral-400 text-sm mt-3 text-center px-4">
+                  {album.description}
+                </Text>
+              )}
+            </View>
+
+            {/* Control Buttons */}
+            <View className="flex-row justify-center space-x-4 px-6 pb-6">
+              <TouchableOpacity
+                onPress={handlePlayAll}
+                className="flex-1 bg-blue-500 py-4 rounded-full items-center"
+                disabled={!album.songs || album.songs.length === 0}
+              >
+                <Text className="text-white font-semibold text-lg">
+                  Play All
+                </Text>
+              </TouchableOpacity>
+
+              <TouchableOpacity
+                onPress={handleShuffle}
+                className="bg-neutral-800 px-6 py-4 rounded-full items-center"
+                disabled={!album.songs || album.songs.length === 0}
+              >
+                <Text className="text-neutral-100 font-semibold">🔀</Text>
+              </TouchableOpacity>
+            </View>
+
+            {/* Songs Header */}
+            {album.songs && album.songs.length > 0 && (
+              <View className="px-6 pb-4">
+                <Text className="text-neutral-100 text-lg font-semibold">
+                  Songs
+                </Text>
+              </View>
+            )}
+          </View>
+        }
+        ListEmptyComponent={
+          <View className="flex-1 justify-center items-center py-16">
+            <Text className="text-neutral-400 text-lg">No songs available</Text>
+            <Text className="text-neutral-500 text-sm mt-2">
+              This album doesn&apos;t have any songs yet
+            </Text>
+          </View>
+        }
+      />
+    </View>
+  );
+}

--- a/app/playlist/[id].tsx
+++ b/app/playlist/[id].tsx
@@ -1,0 +1,396 @@
+import {
+  SaavnPlaylist,
+  SaavnSong,
+  getPlaylistDetails,
+} from "@/services/SongApiService";
+import { usePlayerStore } from "@/store/playerStore";
+import { Image } from "expo-image";
+import { router, useLocalSearchParams } from "expo-router";
+import React, { useEffect, useState } from "react";
+import {
+  ActivityIndicator,
+  Alert,
+  FlatList,
+  Text,
+  TouchableOpacity,
+  View,
+} from "react-native";
+
+interface PlaylistDetails extends SaavnPlaylist {
+  songs: SaavnSong[];
+  description?: string;
+  createdBy?: string;
+  isPublic?: boolean;
+}
+
+export default function PlaylistDetailScreen() {
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const [playlist, setPlaylist] = useState<PlaylistDetails | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [draggedSongIndex, setDraggedSongIndex] = useState<number | null>(null);
+
+  const {
+    playNow,
+    addToQueue,
+    shufflePlay,
+    playInOrder,
+    queue,
+    currentTrack,
+    isPlaying,
+  } = usePlayerStore();
+
+  useEffect(() => {
+    if (id) {
+      fetchPlaylistDetails(id);
+    }
+  }, [id]);
+
+  const fetchPlaylistDetails = async (playlistId: string) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await getPlaylistDetails(playlistId);
+
+      if (result) {
+        const playlistDetails: PlaylistDetails = {
+          ...result.playlist,
+          songs: result.songs,
+        };
+        setPlaylist(playlistDetails);
+      } else {
+        setError("Playlist not found");
+      }
+    } catch (err) {
+      setError("Failed to load playlist details");
+      console.error("Playlist fetch error:", err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handlePlayAll = () => {
+    if (playlist?.songs && playlist.songs.length > 0) {
+      playInOrder(playlist.songs);
+    }
+  };
+
+  const handleShuffle = () => {
+    if (playlist?.songs && playlist.songs.length > 0) {
+      const shuffledSongs = [...playlist.songs].sort(() => Math.random() - 0.5);
+      shufflePlay(shuffledSongs);
+    }
+  };
+
+  const handleSongPress = (song: SaavnSong, index: number) => {
+    if (playlist?.songs) {
+      // Play from this song onwards
+      const songsFromIndex = playlist.songs.slice(index);
+      playInOrder(songsFromIndex);
+    }
+  };
+
+  const handleAddToQueue = (song: SaavnSong) => {
+    addToQueue(song);
+    Alert.alert(
+      "Added to Queue",
+      `"${song.name}" has been added to your queue.`
+    );
+  };
+
+  const handleRemoveFromPlaylist = (songIndex: number) => {
+    if (!playlist) return;
+
+    Alert.alert(
+      "Remove Song",
+      "Are you sure you want to remove this song from the playlist?",
+      [
+        { text: "Cancel", style: "cancel" },
+        {
+          text: "Remove",
+          style: "destructive",
+          onPress: () => {
+            const updatedSongs = playlist.songs.filter(
+              (_, index) => index !== songIndex
+            );
+            setPlaylist({
+              ...playlist,
+              songs: updatedSongs,
+              songCount: updatedSongs.length,
+            });
+          },
+        },
+      ]
+    );
+  };
+
+  const handleReorderSongs = (fromIndex: number, toIndex: number) => {
+    if (!playlist || fromIndex === toIndex) return;
+
+    const updatedSongs = [...playlist.songs];
+    const [movedSong] = updatedSongs.splice(fromIndex, 1);
+    updatedSongs.splice(toIndex, 0, movedSong);
+
+    setPlaylist({
+      ...playlist,
+      songs: updatedSongs,
+    });
+  };
+
+  const formatDuration = (seconds?: number) => {
+    if (!seconds) return "--:--";
+    const mins = Math.floor(seconds / 60);
+    const secs = seconds % 60;
+    return `${mins}:${secs.toString().padStart(2, "0")}`;
+  };
+
+  const getTotalDuration = () => {
+    if (!playlist?.songs) return "0:00";
+    const totalSeconds = playlist.songs.reduce(
+      (sum, song) => sum + (song.duration || 0),
+      0
+    );
+    const hours = Math.floor(totalSeconds / 3600);
+    const mins = Math.floor((totalSeconds % 3600) / 60);
+
+    if (hours > 0) {
+      return `${hours}h ${mins}m`;
+    }
+    return `${mins}m`;
+  };
+
+  const renderSongItem = ({
+    item,
+    index,
+  }: {
+    item: SaavnSong;
+    index: number;
+  }) => {
+    const isCurrentSong = currentTrack?.id === item.id;
+    const isDragged = draggedSongIndex === index;
+
+    return (
+      <TouchableOpacity
+        onPress={() => handleSongPress(item, index)}
+        onLongPress={() => {
+          // Start drag mode
+          setDraggedSongIndex(index);
+        }}
+        className={`flex-row items-center p-4 ${
+          isCurrentSong
+            ? "bg-blue-500/20"
+            : isDragged
+              ? "bg-neutral-700"
+              : "active:bg-neutral-800"
+        }`}
+      >
+        {/* Drag Handle */}
+        <TouchableOpacity className="p-2 mr-2">
+          <Text className="text-neutral-500 text-lg">⋮⋮</Text>
+        </TouchableOpacity>
+
+        {/* Song Artwork */}
+        {item.image ? (
+          <Image
+            source={{ uri: item.image }}
+            style={{ width: 48, height: 48, borderRadius: 8 }}
+            transition={200}
+          />
+        ) : (
+          <View className="w-12 h-12 rounded-lg bg-neutral-800 justify-center items-center">
+            <Text className="text-neutral-400 text-xs">♪</Text>
+          </View>
+        )}
+
+        {/* Song Info */}
+        <View className="flex-1 ml-3">
+          <Text
+            className={`text-base font-medium ${
+              isCurrentSong ? "text-blue-500" : "text-neutral-100"
+            }`}
+            numberOfLines={1}
+          >
+            {item.name}
+          </Text>
+          {item.primaryArtists && (
+            <Text className="text-neutral-400 text-sm mt-1" numberOfLines={1}>
+              {item.primaryArtists}
+            </Text>
+          )}
+        </View>
+
+        {/* Duration */}
+        <Text className="text-neutral-400 text-sm ml-2">
+          {formatDuration(item.duration)}
+        </Text>
+
+        {/* More Options */}
+        <TouchableOpacity
+          onPress={() => {
+            Alert.alert(
+              "Song Options",
+              `What would you like to do with "${item.name}"?`,
+              [
+                { text: "Cancel", style: "cancel" },
+                { text: "Add to Queue", onPress: () => handleAddToQueue(item) },
+                {
+                  text: "Remove from Playlist",
+                  style: "destructive",
+                  onPress: () => handleRemoveFromPlaylist(index),
+                },
+              ]
+            );
+          }}
+          className="p-2 ml-2"
+        >
+          <Text className="text-neutral-400 text-lg">⋯</Text>
+        </TouchableOpacity>
+      </TouchableOpacity>
+    );
+  };
+
+  if (loading) {
+    return (
+      <View className="flex-1 bg-neutral-950 justify-center items-center">
+        <ActivityIndicator size="large" color="#3b82f6" />
+        <Text className="text-neutral-400 mt-4">Loading playlist...</Text>
+      </View>
+    );
+  }
+
+  if (error) {
+    return (
+      <View className="flex-1 bg-neutral-950 justify-center items-center px-6">
+        <Text className="text-red-400 text-lg text-center mb-4">{error}</Text>
+        <TouchableOpacity
+          onPress={() => id && fetchPlaylistDetails(id)}
+          className="bg-blue-500 px-6 py-3 rounded-xl"
+        >
+          <Text className="text-white font-semibold">Retry</Text>
+        </TouchableOpacity>
+      </View>
+    );
+  }
+
+  if (!playlist) {
+    return (
+      <View className="flex-1 bg-neutral-950 justify-center items-center">
+        <Text className="text-neutral-400">Playlist not found</Text>
+      </View>
+    );
+  }
+
+  return (
+    <View className="flex-1 bg-neutral-950">
+      <FlatList
+        data={playlist.songs}
+        keyExtractor={(item, index) => `${item.id}-${index}`}
+        renderItem={renderSongItem}
+        contentContainerStyle={{ paddingBottom: 100 }}
+        ListHeaderComponent={
+          <View>
+            {/* Header with back button */}
+            <View className="flex-row items-center justify-between pt-16 pb-4 px-6">
+              <TouchableOpacity onPress={() => router.back()}>
+                <Text className="text-neutral-300 text-2xl">‹</Text>
+              </TouchableOpacity>
+              <TouchableOpacity>
+                <Text className="text-neutral-300 text-2xl">⋯</Text>
+              </TouchableOpacity>
+            </View>
+
+            {/* Playlist Cover and Info */}
+            <View className="items-center px-6 pb-8">
+              {playlist.image ? (
+                <Image
+                  source={{ uri: playlist.image }}
+                  style={{ width: 280, height: 280, borderRadius: 16 }}
+                  transition={300}
+                />
+              ) : (
+                <View className="w-70 h-70 rounded-2xl bg-neutral-800 justify-center items-center">
+                  <Text className="text-neutral-400 text-4xl">📋</Text>
+                </View>
+              )}
+
+              <Text className="text-neutral-100 text-2xl font-bold mt-6 text-center">
+                {playlist.name}
+              </Text>
+
+              {playlist.createdBy && (
+                <Text className="text-neutral-300 text-lg mt-2 text-center">
+                  by {playlist.createdBy}
+                </Text>
+              )}
+
+              <View className="flex-row items-center space-x-4 mt-3">
+                {playlist.songCount && (
+                  <Text className="text-neutral-400 text-sm">
+                    {playlist.songCount} songs
+                  </Text>
+                )}
+                <Text className="text-neutral-400 text-sm">
+                  {getTotalDuration()}
+                </Text>
+                {playlist.followerCount && (
+                  <Text className="text-neutral-400 text-sm">
+                    {playlist.followerCount.toLocaleString()} followers
+                  </Text>
+                )}
+              </View>
+
+              {playlist.description && (
+                <Text className="text-neutral-400 text-sm mt-3 text-center px-4">
+                  {playlist.description}
+                </Text>
+              )}
+            </View>
+
+            {/* Control Buttons */}
+            <View className="flex-row justify-center space-x-4 px-6 pb-6">
+              <TouchableOpacity
+                onPress={handlePlayAll}
+                className="flex-1 bg-blue-500 py-4 rounded-full items-center"
+                disabled={!playlist.songs || playlist.songs.length === 0}
+              >
+                <Text className="text-white font-semibold text-lg">
+                  Play All
+                </Text>
+              </TouchableOpacity>
+
+              <TouchableOpacity
+                onPress={handleShuffle}
+                className="bg-neutral-800 px-6 py-4 rounded-full items-center"
+                disabled={!playlist.songs || playlist.songs.length === 0}
+              >
+                <Text className="text-neutral-100 font-semibold">🔀</Text>
+              </TouchableOpacity>
+            </View>
+
+            {/* Songs Header */}
+            {playlist.songs && playlist.songs.length > 0 && (
+              <View className="px-6 pb-4">
+                <Text className="text-neutral-100 text-lg font-semibold">
+                  Songs
+                </Text>
+                <Text className="text-neutral-400 text-sm mt-1">
+                  Long press and drag to reorder songs
+                </Text>
+              </View>
+            )}
+          </View>
+        }
+        ListEmptyComponent={
+          <View className="flex-1 justify-center items-center py-16">
+            <Text className="text-neutral-400 text-lg">
+              No songs in this playlist
+            </Text>
+            <Text className="text-neutral-500 text-sm mt-2">
+              Add some songs to get started
+            </Text>
+          </View>
+        }
+      />
+    </View>
+  );
+}

--- a/app/playlist/local/[id].tsx
+++ b/app/playlist/local/[id].tsx
@@ -1,0 +1,365 @@
+import ReorderableSongItem from "@/components/ReorderableSongItem";
+import { SaavnSong } from "@/services/SongApiService";
+import { usePlayerStore } from "@/store/playerStore";
+import { Playlist, usePlaylistStore } from "@/store/playlistStore";
+import { Image } from "expo-image";
+import { useLocalSearchParams } from "expo-router";
+import React, { useEffect, useState } from "react";
+import {
+  ActivityIndicator,
+  Alert,
+  FlatList,
+  Modal,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from "react-native";
+
+export default function LocalPlaylistDetailScreen() {
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const { getPlaylist, updatePlaylist, removeSongFromPlaylist } =
+    usePlaylistStore();
+  const [playlist, setPlaylist] = useState<Playlist | null>(null);
+  const [isEditingName, setIsEditingName] = useState(false);
+  const [editName, setEditName] = useState("");
+  const [isEditingDescription, setIsEditingDescription] = useState(false);
+  const [editDescription, setEditDescription] = useState("");
+
+  const { addToQueue, shufflePlay, playInOrder, currentTrack } =
+    usePlayerStore();
+
+  useEffect(() => {
+    if (id) {
+      const foundPlaylist = getPlaylist(id);
+      if (foundPlaylist) {
+        setPlaylist(foundPlaylist);
+        setEditName(foundPlaylist.name);
+        setEditDescription(foundPlaylist.description || "");
+      }
+    }
+  }, [id, getPlaylist]);
+
+  const handlePlayAll = () => {
+    if (playlist?.songs && playlist.songs.length > 0) {
+      playInOrder(playlist.songs);
+    }
+  };
+
+  const handleShuffle = () => {
+    if (playlist?.songs && playlist.songs.length > 0) {
+      const shuffledSongs = [...playlist.songs].sort(() => Math.random() - 0.5);
+      shufflePlay(shuffledSongs);
+    }
+  };
+
+  const handleSongPress = (song: SaavnSong, index: number) => {
+    if (playlist?.songs) {
+      // Play from this song onwards
+      const songsFromIndex = playlist.songs.slice(index);
+      playInOrder(songsFromIndex);
+    }
+  };
+
+  const handleAddToQueue = (song: SaavnSong) => {
+    addToQueue(song);
+    Alert.alert(
+      "Added to Queue",
+      `"${song.name}" has been added to your queue.`
+    );
+  };
+
+  const handleRemoveFromPlaylist = (songIndex: number) => {
+    if (!playlist) return;
+    const song = playlist.songs[songIndex];
+
+    Alert.alert(
+      "Remove Song",
+      `Are you sure you want to remove "${song.name}" from the playlist?`,
+      [
+        { text: "Cancel", style: "cancel" },
+        {
+          text: "Remove",
+          style: "destructive",
+          onPress: () => {
+            removeSongFromPlaylist(playlist.id, song.id);
+            // Update local state
+            const updatedPlaylist = getPlaylist(playlist.id);
+            if (updatedPlaylist) {
+              setPlaylist(updatedPlaylist);
+            }
+          },
+        },
+      ]
+    );
+  };
+
+  const handleMoveSongUp = (index: number) => {
+    if (!playlist || index <= 0) return;
+
+    const newSongs = [...playlist.songs];
+    [newSongs[index - 1], newSongs[index]] = [
+      newSongs[index],
+      newSongs[index - 1],
+    ];
+
+    updatePlaylist(playlist.id, { songs: newSongs });
+    const updatedPlaylist = getPlaylist(playlist.id);
+    if (updatedPlaylist) {
+      setPlaylist(updatedPlaylist);
+    }
+  };
+
+  const handleMoveSongDown = (index: number) => {
+    if (!playlist || index >= playlist.songs.length - 1) return;
+
+    const newSongs = [...playlist.songs];
+    [newSongs[index], newSongs[index + 1]] = [
+      newSongs[index + 1],
+      newSongs[index],
+    ];
+
+    updatePlaylist(playlist.id, { songs: newSongs });
+    const updatedPlaylist = getPlaylist(playlist.id);
+    if (updatedPlaylist) {
+      setPlaylist(updatedPlaylist);
+    }
+  };
+
+  const handleSaveName = () => {
+    if (playlist && editName.trim()) {
+      updatePlaylist(playlist.id, { name: editName.trim() });
+      const updatedPlaylist = getPlaylist(playlist.id);
+      if (updatedPlaylist) {
+        setPlaylist(updatedPlaylist);
+      }
+    }
+    setIsEditingName(false);
+  };
+
+  const handleSaveDescription = () => {
+    if (playlist) {
+      updatePlaylist(playlist.id, { description: editDescription.trim() });
+      const updatedPlaylist = getPlaylist(playlist.id);
+      if (updatedPlaylist) {
+        setPlaylist(updatedPlaylist);
+      }
+    }
+    setIsEditingDescription(false);
+  };
+
+  const formatDuration = (seconds?: number) => {
+    if (!seconds) return "--:--";
+    const mins = Math.floor(seconds / 60);
+    const secs = seconds % 60;
+    return `${mins}:${secs.toString().padStart(2, "0")}`;
+  };
+
+  const getTotalDuration = () => {
+    if (!playlist?.songs) return "0:00";
+    const totalSeconds = playlist.songs.reduce(
+      (sum, song) => sum + (song.duration || 0),
+      0
+    );
+    const hours = Math.floor(totalSeconds / 3600);
+    const mins = Math.floor((totalSeconds % 3600) / 60);
+
+    if (hours > 0) {
+      return `${hours}h ${mins}m`;
+    }
+    return `${mins}m`;
+  };
+
+  const renderSongItem = ({
+    item,
+    index,
+  }: {
+    item: SaavnSong;
+    index: number;
+  }) => {
+    const isCurrentSong = currentTrack?.id === item.id;
+
+    return (
+      <TouchableOpacity
+        onPress={() => handleSongPress(item, index)}
+        className={`flex-row items-center p-4 ${
+          isCurrentSong ? "bg-blue-500/20" : "active:bg-neutral-800"
+        }`}
+      >
+        {/* Song Artwork */}
+        {item.image ? (
+          <Image
+            source={{ uri: item.image }}
+            style={{ width: 48, height: 48, borderRadius: 8 }}
+            transition={200}
+          />
+        ) : (
+          <View className="w-12 h-12 rounded-lg bg-neutral-800 justify-center items-center">
+            <Text className="text-neutral-400 text-xs">♪</Text>
+          </View>
+        )}
+
+        {/* Song Info */}
+        <View className="flex-1 ml-3">
+          <Text
+            className={`text-base font-medium ${
+              isCurrentSong ? "text-blue-500" : "text-neutral-100"
+            }`}
+            numberOfLines={1}
+          >
+            {item.name}
+          </Text>
+          {item.primaryArtists && (
+            <Text className="text-neutral-400 text-sm mt-1" numberOfLines={1}>
+              {item.primaryArtists}
+            </Text>
+          )}
+        </View>
+
+        {/* Duration */}
+        <Text className="text-neutral-400 text-sm ml-2">
+          {formatDuration(item.duration)}
+        </Text>
+
+        {/* More Options */}
+        <TouchableOpacity
+          onPress={() => {
+            Alert.alert(
+              "Song Options",
+              `What would you like to do with "${item.name}"?`,
+              [
+                { text: "Cancel", style: "cancel" },
+                { text: "Add to Queue", onPress: () => handleAddToQueue(item) },
+                {
+                  text: "Remove from Playlist",
+                  style: "destructive",
+                  onPress: () => handleRemoveFromPlaylist(index),
+                },
+              ]
+            );
+          }}
+          className="p-2 ml-2"
+        >
+          <Text className="text-neutral-400 text-lg">⋯</Text>
+        </TouchableOpacity>
+      </TouchableOpacity>
+    );
+  };
+
+  if (!playlist) {
+    return (
+      <View className="flex-1 bg-neutral-950 justify-center items-center">
+        <ActivityIndicator size="large" color="#3b82f6" />
+        <Text className="text-neutral-400 mt-4">Loading playlist...</Text>
+      </View>
+    );
+  }
+
+  return (
+    <View className="flex-1 bg-neutral-950">
+      <FlatList
+        data={playlist.songs}
+        keyExtractor={(song, index) => `${song.id}-${index}`}
+        renderItem={({ item: song, index }) => (
+          <ReorderableSongItem
+            song={song}
+            index={index}
+            showTrackNumber={true}
+            onPress={() => handleSongPress(song, index)}
+            onMoveUp={() => handleMoveSongUp(index)}
+            onMoveDown={() => handleMoveSongDown(index)}
+            onAddToQueue={() => handleAddToQueue(song)}
+            onRemove={() => handleRemoveFromPlaylist(index)}
+            canMoveUp={index > 0}
+            canMoveDown={index < playlist.songs.length - 1}
+            showRemove={true}
+          />
+        )}
+      />
+      {/* Edit Name Modal */}
+      <Modal
+        visible={isEditingName}
+        transparent
+        animationType="slide"
+        onRequestClose={() => setIsEditingName(false)}
+      >
+        <View className="flex-1 bg-black/50 justify-center px-6">
+          <View className="bg-neutral-900 rounded-2xl p-6">
+            <Text className="text-neutral-100 text-xl font-semibold mb-4 text-center">
+              Edit Playlist Name
+            </Text>
+            <TextInput
+              value={editName}
+              onChangeText={setEditName}
+              placeholder="Playlist name"
+              placeholderTextColor="#737373"
+              className="bg-neutral-800 text-neutral-100 px-4 py-3 rounded-xl mb-6"
+              autoFocus
+            />
+            <View className="flex-row space-x-3">
+              <TouchableOpacity
+                onPress={() => setIsEditingName(false)}
+                className="flex-1 bg-neutral-800 py-3 rounded-xl"
+              >
+                <Text className="text-neutral-300 text-center font-semibold">
+                  Cancel
+                </Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                onPress={handleSaveName}
+                className="flex-1 bg-blue-500 py-3 rounded-xl"
+              >
+                <Text className="text-white text-center font-semibold">
+                  Save
+                </Text>
+              </TouchableOpacity>
+            </View>
+          </View>
+        </View>
+      </Modal>
+      {/* Edit Description Modal */}
+      <Modal
+        visible={isEditingDescription}
+        transparent
+        animationType="slide"
+        onRequestClose={() => setIsEditingDescription(false)}
+      >
+        <View className="flex-1 bg-black/50 justify-center px-6">
+          <View className="bg-neutral-900 rounded-2xl p-6">
+            <Text className="text-neutral-100 text-xl font-semibold mb-4 text-center">
+              Edit Description
+            </Text>
+            <TextInput
+              value={editDescription}
+              onChangeText={setEditDescription}
+              placeholder="Playlist description"
+              placeholderTextColor="#737373"
+              className="bg-neutral-800 text-neutral-100 px-4 py-3 rounded-xl mb-6"
+              multiline
+              numberOfLines={3}
+              autoFocus
+            />
+            <View className="flex-row space-x-3">
+              <TouchableOpacity
+                onPress={() => setIsEditingDescription(false)}
+                className="flex-1 bg-neutral-800 py-3 rounded-xl"
+              >
+                <Text className="text-neutral-300 text-center font-semibold">
+                  Cancel
+                </Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                onPress={handleSaveDescription}
+                className="flex-1 bg-blue-500 py-3 rounded-xl"
+              >
+                <Text className="text-white text-center font-semibold">
+                  Save
+                </Text>
+              </TouchableOpacity>
+            </View>
+          </View>
+        </View>
+      </Modal>
+    </View>
+  );
+}

--- a/app/playlists.tsx
+++ b/app/playlists.tsx
@@ -43,7 +43,10 @@ export default function PlaylistsScreen() {
   };
 
   const renderPlaylist = ({ item }: { item: Playlist }) => (
-    <TouchableOpacity className="bg-neutral-900 rounded-xl p-4 mb-3 active:bg-neutral-800">
+    <TouchableOpacity
+      onPress={() => router.push(`/playlist/local/${item.id}`)}
+      className="bg-neutral-900 rounded-xl p-4 mb-3 active:bg-neutral-800"
+    >
       <View className="flex-row items-center">
         {/* Playlist Cover */}
         <View className="w-16 h-16 rounded-lg bg-neutral-800 justify-center items-center mr-4">

--- a/components/DraggableSongItem.tsx
+++ b/components/DraggableSongItem.tsx
@@ -1,0 +1,129 @@
+import { SaavnSong } from "@/services/SongApiService";
+import { Image } from "expo-image";
+import { useState } from "react";
+import {
+  GestureHandlerRootView,
+  PanGestureHandler,
+  Text,
+  TouchableOpacity,
+  View,
+} from "react-native";
+
+interface DraggableSongItemProps {
+  song: SaavnSong;
+  index: number;
+  isCurrentSong: boolean;
+  onPress: () => void;
+  onLongPress: () => void;
+  onDragStart?: (index: number) => void;
+  onDragEnd?: (fromIndex: number, toIndex: number) => void;
+  formatDuration: (seconds?: number) => string;
+}
+
+export default function DraggableSongItem({
+  song,
+  index,
+  isCurrentSong,
+  onPress,
+  onLongPress,
+  onDragStart,
+  onDragEnd,
+  formatDuration,
+}: DraggableSongItemProps) {
+  const [isDragging, setIsDragging] = useState(false);
+
+  const handleGestureEvent = (event: any) => {
+    // Handle drag gesture
+    const { translationY } = event.nativeEvent;
+    // This is a simplified version - you might want to use react-native-reanimated for smoother animations
+  };
+
+  const handleStateChange = (event: any) => {
+    if (event.nativeEvent.state === 4) {
+      // GESTURE_STATE_END
+      setIsDragging(false);
+      // Calculate drop position and call onDragEnd
+    }
+  };
+
+  return (
+    <GestureHandlerRootView>
+      <PanGestureHandler
+        onGestureEvent={handleGestureEvent}
+        onHandlerStateChange={handleStateChange}
+        enabled={true}
+      >
+        <View
+          className={`flex-row items-center p-4 ${
+            isCurrentSong
+              ? "bg-blue-500/20"
+              : isDragging
+                ? "bg-neutral-700"
+                : "active:bg-neutral-800"
+          }`}
+        >
+          {/* Drag Handle */}
+          <TouchableOpacity
+            className="p-2 mr-2"
+            onPressIn={() => {
+              setIsDragging(true);
+              onDragStart?.(index);
+            }}
+          >
+            <Text className="text-neutral-500 text-lg">⋮⋮</Text>
+          </TouchableOpacity>
+
+          {/* Song Content */}
+          <TouchableOpacity
+            onPress={onPress}
+            onLongPress={onLongPress}
+            className="flex-1 flex-row items-center"
+          >
+            {/* Song Artwork */}
+            {song.image ? (
+              <Image
+                source={{ uri: song.image }}
+                style={{ width: 48, height: 48, borderRadius: 8 }}
+                transition={200}
+              />
+            ) : (
+              <View className="w-12 h-12 rounded-lg bg-neutral-800 justify-center items-center">
+                <Text className="text-neutral-400 text-xs">♪</Text>
+              </View>
+            )}
+
+            {/* Song Info */}
+            <View className="flex-1 ml-3">
+              <Text
+                className={`text-base font-medium ${
+                  isCurrentSong ? "text-blue-500" : "text-neutral-100"
+                }`}
+                numberOfLines={1}
+              >
+                {song.name}
+              </Text>
+              {song.primaryArtists && (
+                <Text
+                  className="text-neutral-400 text-sm mt-1"
+                  numberOfLines={1}
+                >
+                  {song.primaryArtists}
+                </Text>
+              )}
+            </View>
+
+            {/* Duration */}
+            <Text className="text-neutral-400 text-sm ml-2">
+              {formatDuration(song.duration)}
+            </Text>
+          </TouchableOpacity>
+
+          {/* More Options */}
+          <TouchableOpacity onPress={onLongPress} className="p-2 ml-2">
+            <Text className="text-neutral-400 text-lg">⋯</Text>
+          </TouchableOpacity>
+        </View>
+      </PanGestureHandler>
+    </GestureHandlerRootView>
+  );
+}

--- a/components/ReorderableSongItem.tsx
+++ b/components/ReorderableSongItem.tsx
@@ -1,0 +1,153 @@
+import { SaavnSong } from "@/services/SongApiService";
+import { Image } from "expo-image";
+import React from "react";
+import { Alert, AlertButton, Text, TouchableOpacity, View } from "react-native";
+
+interface ReorderableSongItemProps {
+  song: SaavnSong;
+  index: number;
+  isCurrentSong?: boolean;
+  onPress: () => void;
+  onMoveUp?: () => void;
+  onMoveDown?: () => void;
+  onRemove?: () => void;
+  onAddToQueue?: () => void;
+  formatDuration?: (seconds?: number) => string;
+  canMoveUp?: boolean;
+  canMoveDown?: boolean;
+  showTrackNumber?: boolean;
+  showRemove?: boolean;
+}
+
+export default function ReorderableSongItem({
+  song,
+  index,
+  isCurrentSong = false,
+  onPress,
+  onMoveUp,
+  onMoveDown,
+  onRemove,
+  onAddToQueue,
+  formatDuration,
+  canMoveUp = false,
+  canMoveDown = false,
+  showTrackNumber = false,
+  showRemove = false,
+}: ReorderableSongItemProps) {
+  const defaultFormatDuration = (seconds?: number) => {
+    if (!seconds) return "0:00";
+    const mins = Math.floor(seconds / 60);
+    const secs = seconds % 60;
+    return `${mins}:${secs.toString().padStart(2, "0")}`;
+  };
+
+  const handleOptionsPress = () => {
+    const options: AlertButton[] = [{ text: "Cancel", style: "cancel" }];
+
+    if (onAddToQueue) {
+      options.splice(-1, 0, { text: "Add to Queue", onPress: onAddToQueue });
+    }
+
+    if (onRemove && showRemove) {
+      options.splice(-1, 0, {
+        text: "Remove",
+        style: "destructive",
+        onPress: onRemove,
+      });
+    }
+
+    if (canMoveUp && onMoveUp) {
+      options.splice(-1, 0, { text: "Move Up", onPress: onMoveUp });
+    }
+
+    if (canMoveDown && onMoveDown) {
+      options.splice(-1, 0, { text: "Move Down", onPress: onMoveDown });
+    }
+
+    Alert.alert(
+      "Song Options",
+      `What would you like to do with "${song.name}"?`,
+      options
+    );
+  };
+
+  return (
+    <TouchableOpacity
+      onPress={onPress}
+      className={`flex-row items-center p-4 ${
+        isCurrentSong ? "bg-blue-500/20" : "active:bg-neutral-800"
+      }`}
+    >
+      {/* Track Number */}
+      {showTrackNumber && (
+        <View className="w-8 items-center mr-3">
+          <Text
+            className={`text-sm ${isCurrentSong ? "text-blue-500" : "text-neutral-400"}`}
+          >
+            {(index + 1).toString().padStart(2, "0")}
+          </Text>
+        </View>
+      )}
+
+      {/* Song Artwork */}
+      {song.image ? (
+        <Image
+          source={{ uri: song.image }}
+          style={{ width: 48, height: 48, borderRadius: 8 }}
+          transition={200}
+        />
+      ) : (
+        <View className="w-12 h-12 rounded-lg bg-neutral-800 justify-center items-center">
+          <Text className="text-neutral-400 text-xs">♪</Text>
+        </View>
+      )}
+
+      {/* Song Info */}
+      <View className="flex-1 ml-3">
+        <Text
+          className={`text-base font-medium ${
+            isCurrentSong ? "text-blue-500" : "text-neutral-100"
+          }`}
+          numberOfLines={1}
+        >
+          {song.name}
+        </Text>
+        {song.primaryArtists && (
+          <Text className="text-neutral-400 text-sm mt-1" numberOfLines={1}>
+            {song.primaryArtists}
+          </Text>
+        )}
+      </View>
+
+      {/* Duration */}
+      <Text className="text-neutral-400 text-sm ml-2">
+        {(formatDuration || defaultFormatDuration)(song.duration)}
+      </Text>
+
+      {/* Reorder Controls */}
+      {(canMoveUp || canMoveDown) && (
+        <View className="flex-col ml-2">
+          <TouchableOpacity
+            onPress={onMoveUp}
+            disabled={!canMoveUp}
+            className={`p-1 ${!canMoveUp ? "opacity-30" : ""}`}
+          >
+            <Text className="text-neutral-400 text-xs">▲</Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            onPress={onMoveDown}
+            disabled={!canMoveDown}
+            className={`p-1 ${!canMoveDown ? "opacity-30" : ""}`}
+          >
+            <Text className="text-neutral-400 text-xs">▼</Text>
+          </TouchableOpacity>
+        </View>
+      )}
+
+      {/* More Options */}
+      <TouchableOpacity onPress={handleOptionsPress} className="p-2 ml-2">
+        <Text className="text-neutral-400 text-lg">⋯</Text>
+      </TouchableOpacity>
+    </TouchableOpacity>
+  );
+}

--- a/components/search/AlbumsTab.tsx
+++ b/components/search/AlbumsTab.tsx
@@ -1,6 +1,7 @@
 import { SaavnAlbum } from "@/services/SongApiService";
 import { useSearchStore } from "@/store/searchStore";
 import { Image } from "expo-image";
+import { router } from "expo-router";
 import React from "react";
 import {
   ActivityIndicator,
@@ -15,7 +16,7 @@ export default function AlbumsTab() {
     useSearchStore();
 
   const handleAlbumPress = (album: SaavnAlbum) => {
-    // TODO: Navigate to album details page
+    router.push(`/album/${album.id}`);
   };
 
   const handleLoadMore = () => {

--- a/components/search/PlaylistsTab.tsx
+++ b/components/search/PlaylistsTab.tsx
@@ -1,6 +1,7 @@
 import { SaavnPlaylist } from "@/services/SongApiService";
 import { useSearchStore } from "@/store/searchStore";
 import { Image } from "expo-image";
+import { router } from "expo-router";
 import React from "react";
 import {
   ActivityIndicator,
@@ -15,7 +16,7 @@ export default function PlaylistsTab() {
     useSearchStore();
 
   const handlePlaylistPress = (playlist: SaavnPlaylist) => {
-    // TODO: Navigate to playlist details page
+    router.push(`/playlist/${playlist.id}`);
   };
 
   const handleLoadMore = () => {

--- a/services/SongApiService.ts
+++ b/services/SongApiService.ts
@@ -11,6 +11,7 @@ export interface SaavnSong {
   id: string;
   name: string;
   album?: string;
+  albumId?: string;
   year?: string;
   primaryArtists?: string;
   image?: string; // largest image url
@@ -160,10 +161,16 @@ function mapSong(raw: any): SaavnSong {
     (raw.album && typeof raw.album === "object" ? raw.album.name : raw.album) ||
     raw.album_name;
 
+  // Album ID extraction
+  const albumId =
+    (raw.album && typeof raw.album === "object" ? raw.album.id : undefined) ||
+    raw.album_id;
+
   return {
     id: raw.id,
     name: raw.name || raw.title,
     album: albumName,
+    albumId,
     year: raw.year,
     primaryArtists,
     image,
@@ -542,10 +549,54 @@ export async function getAlbum(id: string): Promise<SaavnAlbum | null> {
   return entry ? mapAlbum(entry) : null;
 }
 
+export async function getAlbumDetails(id: string): Promise<{
+  album: SaavnAlbum;
+  songs: SaavnSong[];
+} | null> {
+  try {
+    const data = await api<any>(`/albums?id=${encodeURIComponent(id)}`);
+    const entry = Array.isArray(data.data) ? data.data[0] : data.data;
+
+    if (!entry) return null;
+
+    const album = mapAlbum(entry);
+    const songs = (entry.songs || [])
+      .map(mapSong)
+      .filter((song: SaavnSong) => song.id);
+
+    return { album, songs };
+  } catch (error) {
+    console.error("Failed to fetch album details:", error);
+    return null;
+  }
+}
+
 export async function getPlaylist(id: string): Promise<SaavnPlaylist | null> {
   const data = await api<any>(`/playlists?id=${encodeURIComponent(id)}`);
   const entry = Array.isArray(data.data) ? data.data[0] : data.data;
   return entry ? mapPlaylist(entry) : null;
+}
+
+export async function getPlaylistDetails(id: string): Promise<{
+  playlist: SaavnPlaylist;
+  songs: SaavnSong[];
+} | null> {
+  try {
+    const data = await api<any>(`/playlists?id=${encodeURIComponent(id)}`);
+    const entry = Array.isArray(data.data) ? data.data[0] : data.data;
+
+    if (!entry) return null;
+
+    const playlist = mapPlaylist(entry);
+    const songs = (entry.songs || [])
+      .map(mapSong)
+      .filter((song: SaavnSong) => song.id);
+
+    return { playlist, songs };
+  } catch (error) {
+    console.error("Failed to fetch playlist details:", error);
+    return null;
+  }
 }
 
 export async function incrementPlayAndMaybeCache(song: SaavnSong) {
@@ -841,11 +892,11 @@ export function getRecentlyPlayedAlbums(): SaavnAlbum[] {
   const albumsMap = new Map<string, SaavnAlbum>();
 
   memory.recentlyPlayed.forEach((song: SaavnSong) => {
-    if (song.album && song.id) {
-      const albumId = `${song.album}-${song.primaryArtists}`;
-      if (!albumsMap.has(albumId)) {
-        albumsMap.set(albumId, {
-          id: albumId,
+    if (song.album && song.albumId) {
+      // Use the actual album ID from the API
+      if (!albumsMap.has(song.albumId)) {
+        albumsMap.set(song.albumId, {
+          id: song.albumId,
           name: song.album,
           image: song.image,
           primaryArtists: song.primaryArtists,
@@ -867,7 +918,9 @@ export const SaavnService = {
   searchAll,
   getSong,
   getAlbum,
+  getAlbumDetails,
   getPlaylist,
+  getPlaylistDetails,
   incrementPlayAndMaybeCache,
   getPlayCount,
   isDownloaded,

--- a/services/TrackPlayerService.ts
+++ b/services/TrackPlayerService.ts
@@ -3,7 +3,7 @@ import TrackPlayer, {
   Capability,
   Event,
   RepeatMode,
-} from 'react-native-track-player';
+} from "react-native-track-player";
 
 export const DefaultRepeatMode = RepeatMode.Queue;
 export const DefaultAudioServiceBehaviour =
@@ -36,11 +36,11 @@ export const setupPlayer = async () => {
         Capability.SkipToNext,
         Capability.SkipToPrevious,
       ],
-      progressUpdateEventInterval: 2,
+      progressUpdateEventInterval: 1,
     });
     await TrackPlayer.setRepeatMode(DefaultRepeatMode);
   } catch (error) {
-    console.error('Error setting up player:', error);
+    console.error("Error setting up player:", error);
     throw error;
   }
 };
@@ -49,14 +49,17 @@ const TrackPlayerService = async () => {
   try {
     TrackPlayer.addEventListener(Event.RemotePlay, () => TrackPlayer.play());
     TrackPlayer.addEventListener(Event.RemotePause, () => TrackPlayer.pause());
-    TrackPlayer.addEventListener(Event.RemoteNext, () => TrackPlayer.skipToNext());
-    TrackPlayer.addEventListener(Event.RemotePrevious, () => TrackPlayer.skipToPrevious());
+    TrackPlayer.addEventListener(Event.RemoteNext, () =>
+      TrackPlayer.skipToNext()
+    );
+    TrackPlayer.addEventListener(Event.RemotePrevious, () =>
+      TrackPlayer.skipToPrevious()
+    );
     TrackPlayer.addEventListener(Event.RemoteSeek, (data) => {
       TrackPlayer.seekTo(data.position);
     });
-  }
-  catch (error) {
-    console.error('Error in TrackPlayerService:', error);
+  } catch (error) {
+    console.error("Error in TrackPlayerService:", error);
   }
 };
 export default TrackPlayerService;

--- a/store/playerStore.ts
+++ b/store/playerStore.ts
@@ -31,6 +31,7 @@ interface PlayerState {
   playNow: (song: SaavnSong) => Promise<void>;
   clearQueue: () => Promise<void>;
   shufflePlay: (songs: SaavnSong[]) => Promise<void>;
+  playInOrder: (songs: SaavnSong[]) => Promise<void>;
 
   // State updaters
   setCurrentTrack: (track: Track | null) => void;
@@ -200,6 +201,42 @@ export const usePlayerStore = create<PlayerState>()(
           await incrementPlayAndMaybeCache(shuffledSongs[0]);
         } catch (e) {
           console.warn("Failed to shuffle play:", e);
+        }
+      },
+
+      playInOrder: async (songs: SaavnSong[]) => {
+        try {
+          if (songs.length === 0) return;
+
+          const tracks: Track[] = songs
+            .filter((song) => song.downloadUrl)
+            .map((song) => ({
+              id: song.id,
+              url: song.downloadUrl!,
+              title: song.name,
+              artist: song.primaryArtists,
+              artwork: song.image,
+              album: song.album,
+              duration: song.duration,
+            }));
+
+          if (tracks.length === 0) return;
+
+          await TrackPlayer.reset();
+          await TrackPlayer.add(tracks);
+          await TrackPlayer.play();
+
+          set({
+            queue: tracks,
+            currentIndex: 0,
+            currentTrack: tracks[0],
+            isPlaying: true,
+          });
+
+          // Track play count for first song
+          await incrementPlayAndMaybeCache(songs[0]);
+        } catch (e) {
+          console.warn("Failed to play in order:", e);
         }
       },
 


### PR DESCRIPTION
- Added `PlaylistDetailScreen` for displaying playlist details and songs.
- Integrated song playback controls: play all, shuffle, add to queue, and remove from playlist.
- Implemented song reordering functionality with drag-and-drop support.
- Created `LocalPlaylistDetailScreen` for managing local playlists with editing capabilities.
- Enhanced `PlaylistsScreen` to navigate to local playlist details.
- Introduced `DraggableSongItem` and `ReorderableSongItem` components for better song item management.
- Updated `SongApiService` to fetch album and playlist details.
- Added navigation for album and playlist details in search components.
- Improved player store with new playInOrder functionality for sequential playback.